### PR TITLE
Big div

### DIFF
--- a/contracts/math/BigDiv.sol
+++ b/contracts/math/BigDiv.sol
@@ -1,0 +1,265 @@
+pragma solidity ^0.5.0;
+
+
+import '@openzeppelin/contracts/math/SafeMath.sol';
+
+/**
+ * @title Reduces the size of terms before multiplication, to avoid an overflow, and then
+ * restores the proper size after division.
+ * @notice This effectively allows us to overflow values in the numerator and/or denominator
+ * of a fraction, so long as the end result does not overflow as well.
+*/
+library BigDiv
+{
+  using SafeMath for uint256;
+
+  /// @notice The max possible value
+  uint256 constant MAX_UINT = 2**256 - 1;
+
+  /// @notice When multiplying 2 terms <= this value the result won't overflow
+  uint256 constant MAX_BEFORE_SQUARE = 2**128 - 1;
+
+  /// @notice The max error target is off by 1 plus up to 0.000001% error
+  /// for bigDiv2x1 and that `* 2` for bigDiv2x2
+  uint256 constant MAX_ERROR = 100000000;
+
+  /// @notice A larger error threshold to use when multiple rounding errors may apply
+  uint256 constant MAX_ERROR_BEFORE_DIV = MAX_ERROR * 2;
+
+  /// @notice Represents 1 full token (with 18 decimals)
+  uint256 constant DECIMAL_DIGITS = 10 ** 18;
+
+  /**
+   * @notice Returns the approx result of `a * b / d` so long as the result is <= MAX_UINT
+   * @param _numA the first numerator term
+   * @param _numB the second numerator term
+   * @param _den the denominator
+   * @return the approx result with up to off by 1 + MAX_ERROR, rounding down if needed
+   */
+  function bigDiv2x1(
+    uint256 _numA,
+    uint256 _numB,
+    uint256 _den
+  ) public pure
+    returns(uint256)
+  {
+    if(_numA == 0 || _numB == 0)
+    {
+      // would div by 0 or underflow if we don't special case 0
+      return 0;
+    }
+
+    uint256 value;
+
+    if(MAX_UINT / _numA >= _numB)
+    {
+      // a*b does not overflow, return exact math
+      value = _numA * _numB;
+      value /= _den;
+      return value;
+    }
+
+    // Sort numerators
+    uint256 numMax = _numB;
+    uint256 numMin = _numA;
+    if(_numA > _numB)
+    {
+      numMax = _numA;
+      numMin = _numB;
+    }
+
+    value = numMax / _den;
+    if(value > MAX_ERROR)
+    {
+      // _den is small enough to be MAX_ERROR or better w/o a factor
+      value = value.mul(numMin);
+      return value;
+    }
+
+    // formula = ((a / f) * b) / (d / f)
+    // factor >= a / sqrt(MAX) * (b / sqrt(MAX))
+    uint256 factor = numMin - 1;
+    factor /= MAX_BEFORE_SQUARE;
+    factor += 1;
+    uint256 temp = numMax - 1;
+    temp /= MAX_BEFORE_SQUARE;
+    temp += 1;
+    if(MAX_UINT / factor >= temp)
+    {
+      factor *= temp;
+      value = numMax / factor;
+      if(value > MAX_ERROR_BEFORE_DIV)
+      {
+        value = value.mul(numMin);
+        temp = _den - 1;
+        temp /= factor;
+        temp = temp.add(1);
+        value /= temp;
+        return value;
+      }
+    }
+
+    // formula: (a / (d / f)) * (b / f)
+    // factor: b / sqrt(MAX)
+    factor = numMin - 1;
+    factor /= MAX_BEFORE_SQUARE;
+    factor += 1;
+    value = numMin / factor;
+    temp = _den - 1;
+    temp /= factor;
+    temp += 1;
+    temp = numMax / temp;
+    value = value.mul(temp);
+    return value;
+  }
+
+  /**
+   * @notice Returns the approx result of `a * b / d` so long as the result is <= MAX_UINT
+   * @param _numA the first numerator term
+   * @param _numB the second numerator term
+   * @param _den the denominator
+   * @param _roundUp if true, the math may round the final value up from the exact expected value
+   * @return the approx result with up to off by 1 + MAX_ERROR, rounding down if needed
+   * @dev _roundUp is implemented by first rounding down and then adding the max error to the result
+   */
+  function bigDiv2x1(
+    uint256 _numA,
+    uint256 _numB,
+    uint256 _den,
+    bool _roundUp
+  ) external pure
+    returns(uint256)
+  {
+    // first get the rounded down result
+    uint256 value = bigDiv2x1(_numA, _numB, _den);
+
+    if(_roundUp)
+    {
+      if(value == 0)
+      {
+        // when the value rounds down to 0, assume up to an off by 1 error
+        return 1;
+      }
+
+      // round down has a max error of MAX_ERROR, add that to the result
+      // for a round up error of <= MAX_ERROR
+      uint256 temp = value - 1;
+      temp /= MAX_ERROR;
+      temp += 1;
+      if(MAX_UINT - value < temp)
+      {
+        // value + error would overflow, return MAX
+        return MAX_UINT;
+      }
+
+      value += temp;
+    }
+
+    return value;
+  }
+
+  /**
+   * @notice Returns the approx result of `a * b / (c * d)` so long as the result is <= MAX_UINT
+   * @param _numA the first numerator term
+   * @param _numB the second numerator term
+   * @param _denA the first denominator term
+   * @param _denB the second denominator term
+   * @return the approx result with up to off by 2 + MAX_ERROR*10 error, rounding down if needed
+   * @dev this uses bigDiv2x1 and adds additional rounding error so the max error of this
+   * formula is larger
+   */
+  function bigDiv2x2(
+    uint256 _numA,
+    uint256 _numB,
+    uint256 _denA,
+    uint256 _denB
+  ) external pure
+    returns (uint256)
+  {
+    if(MAX_UINT / _denA >= _denB)
+    {
+      // denA*denB does not overflow, use bigDiv2x1 instead
+      return bigDiv2x1(_numA, _numB, _denA * _denB);
+    }
+
+    if(_numA == 0 || _numB == 0)
+    {
+      // would div by 0 or underflow if we don't special case 0
+      return 0;
+    }
+
+    // Sort denominators
+    uint256 denMax = _denB;
+    uint256 denMin = _denA;
+    if(_denA > _denB)
+    {
+      denMax = _denA;
+      denMin = _denB;
+    }
+
+    uint256 value;
+
+    if(MAX_UINT / _numA >= _numB)
+    {
+      // a*b does not overflow, use `a / d / c`
+      value = _numA * _numB;
+      value /= denMin;
+      value /= denMax;
+      return value;
+    }
+
+    // `ab / cd` where both `ab` and `cd` would overflow
+
+    // Sort numerators
+    uint256 numMax = _numB;
+    uint256 numMin = _numA;
+    if(_numA > _numB)
+    {
+      numMax = _numA;
+      numMin = _numB;
+    }
+
+    // formula = (a/d) * b / c
+    uint256 temp = numMax / denMin;
+    if(temp > MAX_ERROR_BEFORE_DIV)
+    {
+      return bigDiv2x1(temp, numMin, denMax);
+    }
+
+    // formula: ((a/f) * b) / d then either * f / c or / c * f
+    // factor >= a / sqrt(MAX) * (b / sqrt(MAX))
+    uint256 factor = numMin - 1;
+    factor /= MAX_BEFORE_SQUARE;
+    factor += 1;
+    temp = numMax - 1;
+    temp /= MAX_BEFORE_SQUARE;
+    temp += 1;
+    if(MAX_UINT / factor >= temp)
+    {
+      factor *= temp;
+
+      value = numMax / factor;
+      if(value > MAX_ERROR_BEFORE_DIV)
+      {
+        value = value.mul(numMin);
+        value /= denMin;
+        if(value > 0 && MAX_UINT / value >= factor)
+        {
+          value *= factor;
+          value /= denMax;
+          return value;
+        }
+      }
+    }
+
+    // formula: (a/f) * b / ((c*d)/f)
+    // factor >= c / sqrt(MAX) * (d / sqrt(MAX))
+    factor = denMin;
+    factor /= MAX_BEFORE_SQUARE;
+    temp = denMax;
+    // + 1 here prevents overflow of factor*temp
+    temp /= MAX_BEFORE_SQUARE + 1;
+    factor *= temp;
+    return bigDiv2x1(numMax / factor, numMin, MAX_UINT);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardlydifficult-ethereum-contracts",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "A collection of reusable contracts and Javascript helpers for Ethereum.",
   "scripts": {
     "build": "npm run compile",

--- a/test/math/bigDiv.js
+++ b/test/math/bigDiv.js
@@ -1,0 +1,200 @@
+const BigNumber = require("bignumber.js");
+
+const bigDivArtifact = artifacts.require("BigDiv");
+
+contract("math / bigDiv", () => {
+  let contract;
+  const maxValue = new BigNumber(2).pow(256).minus(1);
+
+  before(async () => {
+    contract = await bigDivArtifact.new();
+  });
+
+  it("2x1 does not overflow with sqrt max value", async () => {
+    const sqrtMax = maxValue.sqrt().dp(0);
+    await contract.bigDiv2x1(sqrtMax.toFixed(), 1, 1, false);
+    await contract.bigDiv2x1(1, sqrtMax.toFixed(), 1, false);
+    await contract.bigDiv2x1(1, 1, sqrtMax.toFixed(), false);
+    await contract.bigDiv2x1(
+      sqrtMax.toFixed(),
+      sqrtMax.minus(1).toFixed(),
+      1,
+      false
+    );
+    await contract.bigDiv2x1(
+      sqrtMax.toFixed(),
+      sqrtMax.minus(1).toFixed(),
+      sqrtMax.toFixed(),
+      false
+    );
+  });
+
+  it("2x1 does not overflow with half max value", async () => {
+    await contract.bigDiv2x1(
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      1,
+      1,
+      true
+    );
+    await contract.bigDiv2x1(
+      1,
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      1,
+      true
+    );
+    await contract.bigDiv2x1(
+      1,
+      1,
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      true
+    );
+    await contract.bigDiv2x1(
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      true
+    );
+  });
+
+  it("2x1 does not overflow with max value", async () => {
+    await contract.bigDiv2x1(maxValue.toFixed(), 1, 1, false);
+    await contract.bigDiv2x1(1, maxValue.toFixed(), 1, false);
+    await contract.bigDiv2x1(1, 1, maxValue.toFixed(), false);
+    await contract.bigDiv2x1(maxValue.toFixed(), 1, maxValue.toFixed(), false);
+  });
+
+  it("2x2 does not overflow with sqrt max value", async () => {
+    const sqrtMax = maxValue.sqrt().dp(0);
+    await contract.bigDiv2x2(sqrtMax.toFixed(), 1, 1, 1);
+    await contract.bigDiv2x2(1, sqrtMax.toFixed(), 1, 1);
+    await contract.bigDiv2x2(1, 1, sqrtMax.toFixed(), 1);
+    await contract.bigDiv2x2(1, 1, 1, sqrtMax.toFixed());
+    await contract.bigDiv2x2(
+      sqrtMax.toFixed(),
+      sqrtMax.minus(1).toFixed(),
+      1,
+      1
+    );
+    await contract.bigDiv2x2(
+      sqrtMax.toFixed(),
+      sqrtMax.minus(1).toFixed(),
+      sqrtMax.toFixed(),
+      sqrtMax.minus(1).toFixed()
+    );
+  });
+
+  it("2x2 does not overflow with half max value", async () => {
+    await contract.bigDiv2x2(
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      1,
+      1,
+      1
+    );
+    await contract.bigDiv2x2(
+      1,
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      1,
+      1
+    );
+    await contract.bigDiv2x2(
+      1,
+      1,
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      1
+    );
+    await contract.bigDiv2x2(
+      1,
+      1,
+      1,
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed()
+    );
+    await contract.bigDiv2x2(
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed(),
+      maxValue
+        .div(2)
+        .dp(0)
+        .toFixed()
+    );
+  });
+
+  it("2x2 does not overflow with max value", async () => {
+    await contract.bigDiv2x2(maxValue.toFixed(), 1, 1, 1);
+    await contract.bigDiv2x2(maxValue.toFixed(), 1, maxValue.toFixed(), 1);
+    await contract.bigDiv2x2(
+      maxValue.toFixed(),
+      maxValue.toFixed(),
+      maxValue.toFixed(),
+      1
+    );
+    await contract.bigDiv2x2(
+      maxValue.toFixed(),
+      maxValue.toFixed(),
+      1,
+      maxValue.toFixed()
+    );
+    await contract.bigDiv2x2(1, maxValue.toFixed(), 1, 1);
+    await contract.bigDiv2x2(1, 1, maxValue.toFixed(), 1);
+    await contract.bigDiv2x2(1, 1, 1, maxValue.toFixed());
+  });
+
+  it("MythX detected possible overflow case 1", async () => {
+    const result = await contract.bigDiv2x2(
+      "0x0000000000000000000000000000000000000000000000000000000000000002",
+      "0x0000000000000000000000000000000000000000000000000000000000001700",
+      "0x0000003800000000000000000000000000000000000000000000000000000000",
+      "0x0000fb0000000000000000000000000000000000000000000000000000000000"
+    );
+    assert.equal(result, 0);
+  });
+
+  it("MythX detected possible overflow case 2", async () => {
+    const result = await contract.bigDiv2x2(
+      "2",
+      "5888",
+      "1509757013360435828501352844873099317723680087662272058941802173956096",
+      "1732338333044431510646123721431533388565228352014767025345793580173623296"
+    );
+    assert.equal(result, 0);
+  });
+});

--- a/test/math/bigDivNumbersArray.js
+++ b/test/math/bigDivNumbersArray.js
@@ -1,0 +1,265 @@
+const bigDivArtifact = artifacts.require("BigDiv");
+const BigNumber = require("bignumber.js");
+
+// Goal is up to off by 1 + 0.00001% error for 2x1
+// 2x2 currently checks for off by 2 + 0.0001% error
+const MAX_DELTA_RATIO_FROM_EXPECTED = 0.0000001;
+const MAX_UINT256 = new BigNumber(2).pow(256).minus(1);
+const MAX_UINT192 = new BigNumber(2).pow(192).minus(1);
+const MAX_UINT128 = new BigNumber(2).pow(128).minus(1);
+const MAX_UINT64 = new BigNumber(2).pow(64).minus(1);
+const MAX_UINT32 = new BigNumber(2).pow(32).minus(1);
+
+const numbers = [
+  new BigNumber("0"),
+  new BigNumber("1"),
+  new BigNumber("2"),
+  new BigNumber("3"),
+  new BigNumber("97"),
+  // MAX_UINT32.div('1009').dp(0),
+  // MAX_UINT32.div('10').dp(0),
+  // MAX_UINT32.div('2').dp(0).minus('1'),
+  // MAX_UINT32.div('2').dp(0),
+  // MAX_UINT32.div('2').dp(0).plus('1'),
+  MAX_UINT32.minus("1"),
+  MAX_UINT32,
+  MAX_UINT32.plus("1"),
+  // MAX_UINT32.times('2').minus('1'),
+  // MAX_UINT32.times('2'),
+  // MAX_UINT32.times('2').plus('1'),
+  // MAX_UINT32.times('10'),
+  // MAX_UINT32.times('1009'),
+  // MAX_UINT64.div('1009').dp(0),
+  // MAX_UINT64.div('10').dp(0),
+  MAX_UINT64.div("2")
+    .dp(0)
+    .minus("1"),
+  MAX_UINT64.div("2").dp(0),
+  MAX_UINT64.div("2")
+    .dp(0)
+    .plus("1"),
+  MAX_UINT64.minus("1"),
+  MAX_UINT64,
+  MAX_UINT64.plus("1"),
+  MAX_UINT64.times("2").minus("1"),
+  MAX_UINT64.times("2"),
+  MAX_UINT64.times("2").plus("1"),
+  // MAX_UINT64.times('10'),
+  // MAX_UINT64.times('1009'),
+  // new BigNumber('123456789123456789'),
+  // new BigNumber('849841365163516514614635436'),
+  // new BigNumber('8498413651635165146846416314635436'),
+  // new BigNumber('34028236692093842568444274447460650188'),
+  MAX_UINT128.div("1009").dp(0),
+  MAX_UINT128.div("10").dp(0),
+  MAX_UINT128.div("2")
+    .dp(0)
+    .minus("1"),
+  MAX_UINT128.div("2").dp(0),
+  MAX_UINT128.div("2")
+    .dp(0)
+    .plus("1"),
+  MAX_UINT128.minus("2"),
+  MAX_UINT128.minus("1"),
+  MAX_UINT128,
+  MAX_UINT128.plus("1"),
+  MAX_UINT128.plus("2"),
+  MAX_UINT128.plus("3"),
+  MAX_UINT128.times("2").minus("1"),
+  MAX_UINT128.times("2"),
+  MAX_UINT128.times("2").plus("1"),
+  MAX_UINT128.times("10"),
+  MAX_UINT128.times("1009"),
+  // new BigNumber('99993402823669209384634633746074317682114579999'),
+  // new BigNumber('8888834028236692093846346337460743176821145799999'),
+  // new BigNumber('20892373161954235709850086879078532699846623564056403945759935'),
+  // new BigNumber('2089237316195423570985008687907853269984665640564039457584007913129639935'),
+  // MAX_UINT192.div('1009').dp(0),
+  // MAX_UINT192.div('10').dp(0),
+  MAX_UINT192.div("2")
+    .dp(0)
+    .minus("1"),
+  MAX_UINT192.div("2").dp(0),
+  MAX_UINT192.div("2")
+    .dp(0)
+    .plus("1"),
+  MAX_UINT192.minus("1"),
+  MAX_UINT192,
+  MAX_UINT192.plus("1"),
+  MAX_UINT192.times("2").minus("1"),
+  MAX_UINT192.times("2"),
+  MAX_UINT192.times("2").plus("1"),
+  // MAX_UINT192.times('10'),
+  // MAX_UINT192.times('1009'),
+  MAX_UINT256.div("1009").dp(0),
+  MAX_UINT256.div("10").dp(0),
+  MAX_UINT256.div("2")
+    .dp(0)
+    .minus("1"),
+  MAX_UINT256.div("2").dp(0),
+  MAX_UINT256.div("2")
+    .dp(0)
+    .plus("1"),
+  MAX_UINT256.minus("2"),
+  MAX_UINT256.minus("1"),
+  MAX_UINT256
+];
+
+const getValue = (expectedBN, roundUp, allowIncreasedDiff) => {
+  const maxDiff = new BigNumber(MAX_DELTA_RATIO_FROM_EXPECTED)
+    .times(allowIncreasedDiff ? 2 : 1)
+    .times(expectedBN);
+
+  const maxDiffInt = maxDiff.plus(allowIncreasedDiff ? 2 : 1).dp(0);
+  let minVal;
+  let maxVal;
+
+  if (roundUp) {
+    minVal = expectedBN;
+    maxVal = expectedBN.plus(maxDiffInt);
+  } else {
+    minVal = expectedBN.minus(maxDiffInt);
+    maxVal = expectedBN;
+  }
+
+  return [minVal, maxVal];
+};
+
+// Checks that the difference is no greater than max(1, MAX_DELTA of expectation)
+const checkBounds = (expectedBN, resultBN, roundUp, allowIncreasedDiff) => {
+  const [minVal, maxVal] = getValue(expectedBN, roundUp, allowIncreasedDiff);
+
+  if (maxVal.gt(MAX_UINT256)) {
+    console.log("WARNING: expected value range exceeds MAX_UINT256");
+  }
+
+  assert(
+    resultBN.gte(minVal),
+    `${resultBN.toFixed()} is not >= ${minVal.toFixed()} (and <= ${maxVal.toFixed()})`
+  );
+  assert(
+    resultBN.lte(maxVal),
+    `${resultBN.toFixed()} is not <= ${maxVal.toFixed()} (and >= ${minVal.toFixed()})`
+  );
+};
+
+contract("math / bigDivNumbersArray", () => {
+  let contract;
+
+  before(async () => {
+    contract = await bigDivArtifact.new();
+  });
+
+  const check2x1 = async (numA, numB, den, roundUp) => {
+    let bnRes = new BigNumber(numA)
+      .times(new BigNumber(numB))
+      .div(new BigNumber(den));
+    bnRes = bnRes.dp(0, roundUp ? BigNumber.ROUND_UP : BigNumber.ROUND_DOWN);
+
+    const [, maxVal] = getValue(bnRes, roundUp);
+    if (maxVal.gt(MAX_UINT256)) {
+      return; // skip test as the result may overflow when in expected range
+    }
+
+    const contractRes = new BigNumber(
+      await contract.bigDiv2x1(
+        numA.toFixed(),
+        numB.toFixed(),
+        den.toFixed(),
+        roundUp
+      )
+    );
+
+    checkBounds(bnRes, contractRes, roundUp);
+  };
+
+  const check2x2 = async (numA, numB, denA, denB) => {
+    let res2x2 = new BigNumber(numA)
+      .times(numB)
+      .div(new BigNumber(denA).times(denB));
+    res2x2 = res2x2.dp(0, BigNumber.ROUND_DOWN);
+
+    const [, maxVal] = getValue(res2x2, false, true);
+    if (maxVal.gt(MAX_UINT256)) {
+      return; // skip test as the result may overflow when in expected range
+    }
+
+    const contractRes = new BigNumber(
+      await contract.bigDiv2x2(
+        numA.toFixed(),
+        numB.toFixed(),
+        denA.toFixed(),
+        denB.toFixed()
+      )
+    );
+
+    checkBounds(res2x2, contractRes, false, true);
+  };
+
+  it.skip("test", async () => {
+    await check2x2(
+      new BigNumber(
+        "6277101735386680763835789423207666416102355444464034512896"
+      ),
+      new BigNumber(
+        "6277101735386680763835789423207666416102355444464034512896"
+      ),
+      new BigNumber(
+        "115792089237316195423570985008687907853269984665640564039457584007913129639933"
+      ),
+      new BigNumber(
+        "115792089237316195423570985008687907853269984665640564039457584007913129639933"
+      )
+    );
+  });
+
+  for (let a = numbers.length - 1; a >= 0; a--) {
+    for (let b = a; b < numbers.length; b++) {
+      for (let d = 0; d < numbers.length; d++) {
+        const numA = numbers[a];
+        const numB = numbers[b];
+        const den = numbers[d];
+        if (den.toFixed() !== "0") {
+          it(`bigDiv2x2         ${numA.toFixed()} * ${numB.toFixed()} / (${den.toFixed()} * x)`, async () => {
+            for (let c = d; c < numbers.length; c++) {
+              const denB = numbers[c];
+              const res2x2 = new BigNumber(numA)
+                .times(numB)
+                .div(new BigNumber(den).times(denB));
+              if (res2x2.lte(MAX_UINT256)) {
+                if (
+                  new BigNumber(den)
+                    .times(denB)
+                    .plus(100)
+                    .gte(MAX_UINT256)
+                ) {
+                  console.log(
+                    `${denB.toFixed()} ~= ${res2x2.toExponential(2)}`
+                  );
+                  await check2x2(numA, numB, den, denB);
+                }
+              }
+            }
+          });
+
+          const bnRes = new BigNumber(numA).times(numB).div(den);
+          if (bnRes.lte(MAX_UINT256)) {
+            if (
+              new BigNumber(numA)
+                .times(numB)
+                .plus(100)
+                .gte(MAX_UINT256)
+            ) {
+              it(`bigDiv2x1         ${numA.toFixed()} * ${numB.toFixed()} / ${den.toFixed()} ~= ${bnRes.toExponential(
+                2
+              )}`, async () => {
+                await check2x1(numA, numB, den, false);
+                await check2x1(numA, numB, den, true);
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+});

--- a/test/math/bigDivNumbersArray.js
+++ b/test/math/bigDivNumbersArray.js
@@ -15,7 +15,7 @@ const numbers = [
   new BigNumber("1"),
   new BigNumber("2"),
   new BigNumber("3"),
-  new BigNumber("97"),
+  // new BigNumber("97"),
   // MAX_UINT32.div('1009').dp(0),
   // MAX_UINT32.div('10').dp(0),
   // MAX_UINT32.div('2').dp(0).minus('1'),
@@ -31,27 +31,27 @@ const numbers = [
   // MAX_UINT32.times('1009'),
   // MAX_UINT64.div('1009').dp(0),
   // MAX_UINT64.div('10').dp(0),
-  MAX_UINT64.div("2")
-    .dp(0)
-    .minus("1"),
-  MAX_UINT64.div("2").dp(0),
-  MAX_UINT64.div("2")
-    .dp(0)
-    .plus("1"),
+  // MAX_UINT64.div("2")
+  //   .dp(0)
+  //   .minus("1"),
+  // MAX_UINT64.div("2").dp(0),
+  // MAX_UINT64.div("2")
+  //   .dp(0)
+  //   .plus("1"),
   MAX_UINT64.minus("1"),
   MAX_UINT64,
   MAX_UINT64.plus("1"),
-  MAX_UINT64.times("2").minus("1"),
-  MAX_UINT64.times("2"),
-  MAX_UINT64.times("2").plus("1"),
+  // MAX_UINT64.times("2").minus("1"),
+  // MAX_UINT64.times("2"),
+  // MAX_UINT64.times("2").plus("1"),
   // MAX_UINT64.times('10'),
   // MAX_UINT64.times('1009'),
   // new BigNumber('123456789123456789'),
   // new BigNumber('849841365163516514614635436'),
   // new BigNumber('8498413651635165146846416314635436'),
   // new BigNumber('34028236692093842568444274447460650188'),
-  MAX_UINT128.div("1009").dp(0),
-  MAX_UINT128.div("10").dp(0),
+  // MAX_UINT128.div("1009").dp(0),
+  // MAX_UINT128.div("10").dp(0),
   MAX_UINT128.div("2")
     .dp(0)
     .minus("1"),
@@ -59,36 +59,36 @@ const numbers = [
   MAX_UINT128.div("2")
     .dp(0)
     .plus("1"),
-  MAX_UINT128.minus("2"),
+  // MAX_UINT128.minus("2"),
   MAX_UINT128.minus("1"),
   MAX_UINT128,
   MAX_UINT128.plus("1"),
-  MAX_UINT128.plus("2"),
-  MAX_UINT128.plus("3"),
+  // MAX_UINT128.plus("2"),
+  // MAX_UINT128.plus("3"),
   MAX_UINT128.times("2").minus("1"),
   MAX_UINT128.times("2"),
   MAX_UINT128.times("2").plus("1"),
-  MAX_UINT128.times("10"),
-  MAX_UINT128.times("1009"),
+  // MAX_UINT128.times("10"),
+  // MAX_UINT128.times("1009"),
   // new BigNumber('99993402823669209384634633746074317682114579999'),
   // new BigNumber('8888834028236692093846346337460743176821145799999'),
   // new BigNumber('20892373161954235709850086879078532699846623564056403945759935'),
   // new BigNumber('2089237316195423570985008687907853269984665640564039457584007913129639935'),
   // MAX_UINT192.div('1009').dp(0),
   // MAX_UINT192.div('10').dp(0),
-  MAX_UINT192.div("2")
-    .dp(0)
-    .minus("1"),
-  MAX_UINT192.div("2").dp(0),
-  MAX_UINT192.div("2")
-    .dp(0)
-    .plus("1"),
+  // MAX_UINT192.div("2")
+  //   .dp(0)
+  //   .minus("1"),
+  // MAX_UINT192.div("2").dp(0),
+  // MAX_UINT192.div("2")
+  //   .dp(0)
+  //   .plus("1"),
   MAX_UINT192.minus("1"),
   MAX_UINT192,
   MAX_UINT192.plus("1"),
-  MAX_UINT192.times("2").minus("1"),
-  MAX_UINT192.times("2"),
-  MAX_UINT192.times("2").plus("1"),
+  // MAX_UINT192.times("2").minus("1"),
+  // MAX_UINT192.times("2"),
+  // MAX_UINT192.times("2").plus("1"),
   // MAX_UINT192.times('10'),
   // MAX_UINT192.times('1009'),
   MAX_UINT256.div("1009").dp(0),


### PR DESCRIPTION
Adds the BigDiv contract (ported from Vyper).

Reduces the size of terms before multiplication, to avoid an overflow, and then restores the proper size after division.