### PR TITLE
Rename `sqrt`

### DIFF
--- a/contracts/math/Sqrt.sol
+++ b/contracts/math/Sqrt.sol
@@ -29,7 +29,7 @@ library Sqrt
   }
 
   // Source: https://github.com/ethereum/dapp-bin/pull/50
-  function sqrt(
+  function sqrtUint(
     uint x
   ) public pure
     returns (uint y)

--- a/test/math/sqrtNumbersArray.js
+++ b/test/math/sqrtNumbersArray.js
@@ -176,7 +176,7 @@ contract("math / sqrtNumbersArray", () => {
     let sqrtResult = new BigNumber(x).sqrt();
     it(`sqrt(${x.toFixed()}) ~= ${sqrtResult.toExponential(2)}`, async () => {
       sqrtResult = sqrtResult.dp(0);
-      const contractRes = new BigNumber(await contract.sqrt(x.toFixed()));
+      const contractRes = new BigNumber(await contract.sqrtUint(x.toFixed()));
       checkBounds(sqrtResult, contractRes);
     });
   }


### PR DESCRIPTION
It's a naming conflict for Vyper.